### PR TITLE
chore: package maintenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,18 +23,7 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
-    "./*": {
-      "types": "./dist/*.d.ts",
-      "default": "./dist/*.js"
-    },
     "./package.json": "./package.json"
-  },
-  "typesVersions": {
-    "*": {
-      "*": [
-        "dist/*.d.ts"
-      ]
-    }
   },
   "scripts": {
     "build": "rimraf dist && tsc",
@@ -58,5 +47,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "antelopeJs": {}
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "release": "pnpm run lint && pnpm run prepack && release-it"
   },
   "dependencies": {
-    "@antelopejs/interface-core": "^0.0.2",
+    "@antelopejs/interface-core": "^0.0.3",
     "rethinkdb-ts": "^2.7.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@antelopejs/interface-core':
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.0.3
+        version: 0.0.3
       rethinkdb-ts:
         specifier: ^2.7.0
         version: 2.7.0
@@ -36,8 +36,8 @@ importers:
 
 packages:
 
-  '@antelopejs/interface-core@0.0.2':
-    resolution: {integrity: sha512-CmtOJvSCRj20GOQhrE0PpHybGaW1G1lrepiKHVJa/bclhrvFYgHV0MH84TMpMOHESQT/+wuup007tfXAwaI+Eg==}
+  '@antelopejs/interface-core@0.0.3':
+    resolution: {integrity: sha512-Kw3ffGiQHKJ88AqdFfPuwzl+v0w6QqzqiqnLY7M0MYYw+YwdRNXh5WAJkep0ePudR9leLGXPU//FYizNaDG6yw==}
 
   '@biomejs/biome@2.3.2':
     resolution: {integrity: sha512-8e9tzamuDycx7fdrcJ/F/GDZ8SYukc5ud6tDicjjFqURKYFSWMl0H0iXNXZEGmcmNUmABgGuHThPykcM41INgg==}
@@ -469,6 +469,9 @@ packages:
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
   degenerator@5.0.1:
     resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
@@ -1108,7 +1111,7 @@ packages:
 
 snapshots:
 
-  '@antelopejs/interface-core@0.0.2':
+  '@antelopejs/interface-core@0.0.3':
     dependencies:
       reflect-metadata: 0.2.2
 
@@ -1400,7 +1403,7 @@ snapshots:
     dependencies:
       chokidar: 3.6.0
       confbox: 0.1.8
-      defu: 6.1.4
+      defu: 6.1.7
       dotenv: 16.6.1
       giget: 1.2.5
       jiti: 1.21.7
@@ -1522,6 +1525,8 @@ snapshots:
 
   defu@6.1.4: {}
 
+  defu@6.1.7: {}
+
   degenerator@5.0.1:
     dependencies:
       ast-types: 0.13.4
@@ -1599,7 +1604,7 @@ snapshots:
     dependencies:
       citty: 0.1.6
       consola: 3.4.2
-      defu: 6.1.4
+      defu: 6.1.7
       node-fetch-native: 1.6.7
       nypm: 0.5.4
       pathe: 2.0.3


### PR DESCRIPTION
## Summary
- Add `antelopeJs` field to package.json (empty object for consistency across interface-* repos)
- Remove wildcard subpath exports (`./*` and `typesVersions` wildcard) to hide internal dist paths from consumers
- Bump `@antelopejs/interface-core` dependency to `^0.0.3`

## Test plan
- [ ] Verify build still passes: `pnpm run build`
- [ ] Verify lint still passes: `pnpm run lint`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This maintenance PR removes wildcard subpath exports (`./*` and `typesVersions`) to hide internal `dist` paths from consumers, bumps `@antelopejs/interface-core` to `^0.0.3`, and adds an empty `antelopeJs` field for cross-repo consistency. The lock file is updated accordingly, with a transitive `defu` upgrade from `6.1.4` → `6.1.7` pulled in through the new interface-core version.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are intentional and well-described, with no logic or security concerns.

All changes are non-breaking at the code level (package is pre-1.0, and subpath removal is intentional), the dependency bump is a minor patch, and the lock file reflects expected transitive updates. No P0/P1 findings.

No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Removes wildcard subpath exports and typesVersions wildcard, bumps @antelopejs/interface-core to ^0.0.3, and adds antelopeJs empty object field |
| pnpm-lock.yaml | Lock file updated to reflect @antelopejs/interface-core 0.0.3 and a transitive defu upgrade from 6.1.4 to 6.1.7 |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Consumer imports package] --> B{Subpath used?}
    B -- "No (root import)" --> C["Resolved via '.' export\n./dist/index.js"]
    B -- "Yes (e.g. /utils)" --> D_old["Before PR: resolved via './*'\n./dist/*.js"]
    B -- "Yes (e.g. /utils)" --> D_new["After PR: resolution fails\n(no wildcard export)"]
    C --> E[Works]
    D_old --> F[Works — internal paths exposed]
    D_new --> G[Import error — internal paths hidden]
```

<sub>Reviews (1): Last reviewed commit: ["chore: bump @antelopejs/interface-core t..."](https://github.com/antelopejs/interface-rethinkdb/commit/2dcde58b6aad61d24704e77b1b0fc55a1e2435d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29167019)</sub>

<!-- /greptile_comment -->