### PR TITLE
chore(deps): interface-core as bounded peer + dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,16 +34,19 @@
     "release": "pnpm run lint && pnpm run prepack && release-it"
   },
   "dependencies": {
-    "@antelopejs/interface-core": "^0.0.3",
     "rethinkdb-ts": "^2.7.0"
   },
   "devDependencies": {
+    "@antelopejs/interface-core": ">=0.0.3 <1.0.0",
     "@biomejs/biome": "2.3.2",
     "@types/node": "^22.19.15",
     "release-it": "^19.2.4",
     "release-it-changelogen": "^0.1.0",
     "rimraf": "^6.1.3",
     "typescript": "^5.9.3"
+  },
+  "peerDependencies": {
+    "@antelopejs/interface-core": ">=0.0.3 <1.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,13 +8,13 @@ importers:
 
   .:
     dependencies:
-      '@antelopejs/interface-core':
-        specifier: ^0.0.3
-        version: 0.0.3
       rethinkdb-ts:
         specifier: ^2.7.0
         version: 2.7.0
     devDependencies:
+      '@antelopejs/interface-core':
+        specifier: '>=0.0.3 <1.0.0'
+        version: 0.0.3
       '@biomejs/biome':
         specifier: 2.3.2
         version: 2.3.2


### PR DESCRIPTION
Move `@antelopejs/interface-core` from dependencies to peerDependencies (bounded to the current major, e.g. `>=0.0.5 <0.1.0`) and mirror it in devDependencies for standalone compilation. interface-core is a host-provided runtime singleton; this avoids dual installs and version-pinning overrides downstream. Verified: install, build, lint.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves `@antelopejs/interface-core` from `dependencies` to `peerDependencies` (with a mirrored entry in `devDependencies`), correctly treating it as a host-provided singleton to avoid duplicate installs and downstream version-pinning conflicts.

- `@antelopejs/interface-core` is removed from runtime `dependencies` and added to both `peerDependencies` and `devDependencies` with the range `>=0.0.3 <1.0.0`, allowing the dev environment to build and the consuming host to supply the package.
- The pnpm lockfile is updated accordingly, resolving the dev copy to `0.0.3`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the dependency restructuring is mechanically correct, and the dev and peer ranges are now consistent with each other.

The change correctly removes interface-core from runtime dependencies and places it in both peerDependencies and devDependencies with matching ranges. The only open question is whether the upper bound should be <0.1.0 rather than <1.0.0, since the PR description's example suggested a tighter bound — but this is a minor design choice, not a defect in the restructuring itself.

package.json — worth confirming the intended upper bound of the peer range (<0.1.0 vs <1.0.0).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Moves @antelopejs/interface-core from dependencies to peerDependencies + devDependencies; both use the same range (>=0.0.3 <1.0.0). The range is broader than the PR description's example (which suggested <0.1.0), spanning all 0.x versions where minor bumps can be breaking. |
| pnpm-lock.yaml | Lockfile updated to reflect the move: interface-core removed from runtime dependencies, added under devDependencies resolving to 0.0.3. No issues. |

</details>

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[interface-rethinkdb] --> B[peerDependencies: interface-core >=0.0.3 <1.0.0]
    A --> C[devDependencies: interface-core >=0.0.3 <1.0.0]
    A --> D[dependencies: rethinkdb-ts ^2.7.0]
    E[Downstream consumer app] --> F[installs interface-core as host singleton]
    E --> G[installs interface-rethinkdb]
    G --> B
    F -. satisfies peer .-> B
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[interface-rethinkdb] --> B[peerDependencies: interface-core >=0.0.3 <1.0.0]
    A --> C[devDependencies: interface-core >=0.0.3 <1.0.0]
    A --> D[dependencies: rethinkdb-ts ^2.7.0]
    E[Downstream consumer app] --> F[installs interface-core as host singleton]
    E --> G[installs interface-rethinkdb]
    G --> B
    F -. satisfies peer .-> B
```

</a>

<sub>Reviews (2): Last reviewed commit: ["chore(deps): interface deps as bounded p..."](https://github.com/antelopejs/interface-rethinkdb/commit/3962918c0e6cbc18d7a8daf07f682aebedaf1ea7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37739173)</sub>

<!-- /greptile_comment -->