### PR TITLE
feat(skills): ship a consumer skill with the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "types": "dist/index.d.ts",
   "files": [
     "dist",
+    "docs",
     "skills"
   ],
   "exports": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "skills"
   ],
   "exports": {
     ".": {
@@ -51,5 +52,9 @@
   "publishConfig": {
     "access": "public"
   },
-  "antelopeJs": {}
+  "antelopeJs": {
+    "skills": [
+      "./skills"
+    ]
+  }
 }

--- a/skills/rethinkdb-interface/SKILL.md
+++ b/skills/rethinkdb-interface/SKILL.md
@@ -60,10 +60,10 @@ ImplementInterface(rethinkdbInterface, {
 
 - Never call `.run()` on a query in consumer code — consumers have no connection. Always execute through `RunQuery`; the implementing module manages the connection.
 - `RunQuery` always returns a Promise, even for cursors/atomic values, because it crosses an AsyncProxy.
-- Calls made before an implementation attaches are queued by the AsyncProxy and resolve once a provider registers — they do not fail fast. A missing provider therefore looks like a hang, not an error.
+- Calls made before an implementation attaches are queued by the AsyncProxy and resolve once a provider registers — they do not fail fast. A missing provider therefore looks like a hang, not an error. Under the AntelopeJS test harness (test-stub mode) it instead rejects immediately with the "Interface function called without implementation in test environment" error.
 - `r.now()`, `r.uuid()`, etc. build ReQL terms evaluated server-side at execution time, not local values.
 - `@antelopejs/interface-core` is a peer dependency; the host project provides it.
 
 ## Deeper reference
 
-Full walkthrough (query builder, CRUD, query options, joins, aggregations) is in the repo's `docs/1.introduction.md` (not shipped in the npm package): https://github.com/AntelopeJS/interface-rethinkdb/blob/main/docs/1.introduction.md. Exact types are in `dist/index.d.ts`; the complete ReQL API is documented by RethinkDB and `rethinkdb-ts`. Do not duplicate those here.
+Full walkthrough (query builder, CRUD, query options, joins, aggregations) is in this package's `docs/1.introduction.md`. Exact types are in `dist/index.d.ts`; the complete ReQL API is documented by RethinkDB and `rethinkdb-ts`. Do not duplicate those here.

--- a/skills/rethinkdb-interface/SKILL.md
+++ b/skills/rethinkdb-interface/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: rethinkdb-interface
+description: AntelopeJS interface exposing RethinkDB query execution via RunQuery and the r query builder re-exported from rethinkdb-ts. Use when code imports @antelopejs/interface-rethinkdb, when a task mentions RunQuery, r.table(...), ReQL queries, RethinkDB CRUD/joins/aggregations in an AntelopeJS module, or when implementing the interface with ImplementInterface.
+category: antelopejs-interface
+tags: [antelopejs, rethinkdb, reql, database, queries]
+---
+
+# RethinkDB Interface
+
+Thin AntelopeJS interface over RethinkDB. It exports exactly two things:
+
+- `r` — the ReQL query builder, re-exported unchanged from `rethinkdb-ts`. Building queries with `r` is pure and consumer-side; nothing touches the network.
+- `RunQuery` — the only proxy crossing. It is an `InterfaceFunction` (AsyncProxy): the call is routed to whichever module implements the interface and owns the connection.
+
+## Imports
+
+```typescript
+import { RunQuery, r } from "@antelopejs/interface-rethinkdb";
+```
+
+That single subpath is the whole public surface (`.` in the exports map; `./package.json` is also exported for tooling).
+
+## Consuming
+
+```typescript
+import { RunQuery, r } from "@antelopejs/interface-rethinkdb";
+
+// Read
+const user = await RunQuery(r.table("users").get("123"));
+
+// Write
+const res = await RunQuery(
+  r.table("users").insert({ name: "Ada", createdAt: r.now() }),
+);
+const id = res.generated_keys?.[0]; // only present when the server generated keys
+
+// Optional RunOptions as second argument
+const admins = await RunQuery(
+  r.table("users").filter({ role: "admin" }),
+  { readMode: "outdated" },
+);
+```
+
+`RunQuery<T extends RQuery>(query, options?)` returns `ReturnType<T["run"]>`, so results are typed exactly as if you had called `query.run()` yourself.
+
+## Providing (implementer modules only)
+
+A module that owns a RethinkDB connection implements the interface with `ImplementInterface` from `@antelopejs/interface-core`:
+
+```typescript
+import { ImplementInterface } from "@antelopejs/interface-core";
+import * as rethinkdbInterface from "@antelopejs/interface-rethinkdb";
+
+ImplementInterface(rethinkdbInterface, {
+  RunQuery: (query, options) => query.run(connection, options),
+});
+```
+
+## Gotchas
+
+- Never call `.run()` on a query in consumer code — consumers have no connection. Always execute through `RunQuery`; the implementing module manages the connection.
+- `RunQuery` always returns a Promise, even for cursors/atomic values, because it crosses an AsyncProxy.
+- Calls made before an implementation attaches are queued by the AsyncProxy and resolve once a provider registers — they do not fail fast. A missing provider therefore looks like a hang, not an error.
+- `r.now()`, `r.uuid()`, etc. build ReQL terms evaluated server-side at execution time, not local values.
+- `@antelopejs/interface-core` is a peer dependency; the host project provides it.
+
+## Deeper reference
+
+Full walkthrough (query builder, CRUD, query options, joins, aggregations) is in the repo's `docs/1.introduction.md` (not shipped in the npm package): https://github.com/AntelopeJS/interface-rethinkdb/blob/main/docs/1.introduction.md. Exact types are in `dist/index.d.ts`; the complete ReQL API is documented by RethinkDB and `rethinkdb-ts`. Do not duplicate those here.

--- a/skills/rethinkdb-interface/SKILL.md
+++ b/skills/rethinkdb-interface/SKILL.md
@@ -26,17 +26,17 @@ That single subpath is the whole public surface (`.` in the exports map; `./pack
 import { RunQuery, r } from "@antelopejs/interface-rethinkdb";
 
 // Read
-const user = await RunQuery(r.table("users").get("123"));
+const book = await RunQuery(r.table("books").get("bk-9f2c"));
 
 // Write
 const res = await RunQuery(
-  r.table("users").insert({ name: "Ada", createdAt: r.now() }),
+  r.table("books").insert({ title: "The Icebound Atlas", addedAt: r.now() }),
 );
 const id = res.generated_keys?.[0]; // only present when the server generated keys
 
 // Optional RunOptions as second argument
-const admins = await RunQuery(
-  r.table("users").filter({ role: "admin" }),
+const overdueLoans = await RunQuery(
+  r.table("loans").filter({ status: "overdue" }),
   { readMode: "outdated" },
 );
 ```


### PR DESCRIPTION
## Summary
- Adds `skills/<name>-interface/SKILL.md`: a lean, source-grounded consumer guide (imports per subpath, minimal example, gotchas, pointer to the shipped `.d.ts`)
- Wires it for distribution: `antelopeJs.skills: ["./skills"]` + `skills` in the `files` array
- Consumers get it automatically: the antelopejs Claude Code plugin syncs package-shipped skills into `.claude/skills/`; the cms-ai chatbox loads them at runtime
- Content fact-checked against `src/`/`docs/` by an adversarial review pass (imports validated against the exports map, examples verified against real signatures)

## Test plan
N/A (documentation artifact; frontmatter and import paths validated mechanically)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ships a consumer-facing skill guide (`skills/rethinkdb-interface/SKILL.md`) alongside the package and wires it for distribution via `antelopeJs.skills` and the `files` array.

- **`package.json`**: Adds `docs` and `skills` to the published `files` array and registers `./skills` under `antelopeJs.skills` so the AntelopeJS toolchain can pick up the skill automatically.
- **`skills/rethinkdb-interface/SKILL.md`**: Documents the two public exports (`RunQuery` and `r`), verified accurate against `src/index.ts` — the import path, generic signature `RunQuery<T extends RQuery>(query, options?)`, and `ReturnType<T["run"]>` return type all match the source exactly.

<h3>Confidence Score: 5/5</h3>

Safe to merge — adds only a documentation artifact and two packaging config lines, with no logic changes.

The only code changes are additive entries in `package.json` (`files` and `antelopeJs.skills`). The new SKILL.md content was cross-checked against `src/index.ts` and the exports map: import paths, generic signature, and return type are all accurate. No runtime behavior is touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Adds `docs` and `skills` to the published `files` array and registers `./skills` under `antelopeJs.skills`. Both changes are minimal and correct. |
| skills/rethinkdb-interface/SKILL.md | New consumer-facing skill guide; imports, function signatures, and return type all verified against `src/index.ts` and the exports map in `package.json`. Content is accurate. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Consumer as Consumer Module
    participant Pkg as @antelopejs/interface-rethinkdb
    participant Proxy as AsyncProxy (InterfaceFunction)
    participant Impl as Implementing Module

    Note over Pkg: Published with files[] + antelopeJs.skills
    Consumer->>Pkg: "import { RunQuery, r }"
    Consumer->>Consumer: r.table("books").get(id) — pure, no network
    Consumer->>Proxy: RunQuery(query, options?)
    Proxy->>Impl: routes to registered implementation
    Impl->>Impl: query.run(connection, options)
    Impl-->>Proxy: Promise result
    Proxy-->>Consumer: ReturnType T run
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Consumer as Consumer Module
    participant Pkg as @antelopejs/interface-rethinkdb
    participant Proxy as AsyncProxy (InterfaceFunction)
    participant Impl as Implementing Module

    Note over Pkg: Published with files[] + antelopeJs.skills
    Consumer->>Pkg: "import { RunQuery, r }"
    Consumer->>Consumer: r.table("books").get(id) — pure, no network
    Consumer->>Proxy: RunQuery(query, options?)
    Proxy->>Impl: routes to registered implementation
    Impl->>Impl: query.run(connection, options)
    Impl-->>Proxy: Promise result
    Proxy-->>Consumer: ReturnType T run
```

</a>

<sub>Reviews (5): Last reviewed commit: ["docs(skills): use fictional domains in c..."](https://github.com/antelopejs/interface-rethinkdb/commit/a98ac90982ca616e2055031262819752a2a8a67d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45477203)</sub>

<!-- /greptile_comment -->